### PR TITLE
fix(daemon): Prevent contact name overwrites, merge aliased JID chat histories, and support business/bot messages

### DIFF
--- a/daemon/index.js
+++ b/daemon/index.js
@@ -211,30 +211,42 @@ function ingest(chatJid, raw, { live }) {
   if (isIgnorableChat(chatJid)) return null
   if (isSilent(raw.message)) return null
 
-  const message = flatten(chatJid, raw)
+  learnAliasesFromMessage(raw)
+  const canonicalTarget = store.canonicalJid(chatJid) || chatJid
+
+  const message = flatten(canonicalTarget, raw)
   if (!message.ts) message.ts = Math.floor(Date.now() / 1000)
 
-  const existed = !!store.findMessage(chatJid, message.id)
-  learnAliasesFromMessage(raw)
-  store.upsertMessage(chatJid, message)
-  const chat = store.touchChat(chatJid, message)
-  if (!chat.isGroup && raw.pushName) store.rememberName(chatJid, raw.pushName)
-  resolveGroupName(chatJid)
+  const existed = !!store.findMessage(canonicalTarget, message.id)
+
+  store.upsertMessage(canonicalTarget, message)
+  const chat = store.touchChat(canonicalTarget, message)
+
+  if (!chat.isGroup && !raw.key?.fromMe && raw.pushName) {
+    store.rememberName(canonicalTarget, raw.pushName)
+  }
+
+  const participant = raw.key?.participant || raw.participant
+  if (chat.isGroup && !raw.key?.fromMe && participant && raw.pushName) {
+    store.rememberName(participant, raw.pushName)
+  }
+
+  resolveGroupName(canonicalTarget)
 
   if (live && !existed && !message.fromMe) {
-    store.bumpUnread(chatJid)
+    store.bumpUnread(canonicalTarget)
     if (message.ts >= startedAt) {
       const title = chat.isGroup ? (chat.name || 'Group') : (message.senderName || chat.name)
       const body = chat.isGroup ? `${message.senderName}: ${message.text}` : message.text
-      notifier.queue({ jid: chatJid, title, body, muted: !!chat.muted })
+      notifier.queue({ jid: canonicalTarget, title, body, muted: !!chat.muted })
     }
   }
 
-  const chatKey = normalizeJid(chatJid)
-  if (message.media && !message.imagePath && (live || wantedChats.has(chatKey) || wantedChats.has(chatJid))) {
-    media.enqueue(chatJid, message)
+  const chatKey = normalizeJid(canonicalTarget)
+  if (message.media && !message.imagePath && (live || wantedChats.has(chatKey) || wantedChats.has(canonicalTarget))) {
+    media.enqueue(canonicalTarget, message)
   }
-  return message
+  return { message, canonicalTarget }
 }
 
 function applyChatMetadata(rawChats) {
@@ -703,17 +715,17 @@ async function connect() {
       for (const raw of messages || []) {
         const jid = raw?.key?.remoteJid
         if (!jid) continue
-        const existed = !!store.findMessage(jid, raw?.key?.id)
-        const message = ingest(jid, raw, { live })
-        if (!message) continue
-        // History / media retries must not shove old rows into an open chat.
+        const result = ingest(jid, raw, { live })
+        if (!result) continue
+        const { message, canonicalTarget } = result
+        const existed = !!store.findMessage(canonicalTarget, raw?.key?.id)
         if (!live && existed) continue
         if (!live) continue
         bus.broadcast({
           t: 'message',
-          jid,
+          jid: canonicalTarget,
           message: publicMessage(message),
-          chat: store.chat(jid),
+          chat: store.chat(canonicalTarget),
           unread: store.totalUnread()
         })
       }
@@ -847,49 +859,50 @@ async function handleCommand(payload, reply) {
     case 'messages':
       if (!payload.jid) throw new Error('messages: jid required')
       {
-        const list = store.messageList(payload.jid, payload.limit || 60)
-        wantedChats.add(payload.jid)
+        const canonical = store.canonicalJid(payload.jid) || payload.jid
+        const list = store.messageList(canonical, payload.limit || 60)
+        wantedChats.add(canonical)
         wantedChats.add(normalizeJid(payload.jid))
         reply({
           t: 'messages',
           jid: payload.jid,
-          chat: store.chat(payload.jid),
+          chat: store.chat(canonical),
           messages: list.map(publicMessage)
         })
         for (const message of list) {
-          if (message.media && !existingMediaPath(message)) media.enqueue(payload.jid, message)
+          if (message.media && !existingMediaPath(message)) media.enqueue(canonical, message)
         }
-        refreshMissingImages(payload.jid, list).catch((err) => {
-          logger.debug({ err, jid: payload.jid }, 'media: history refresh failed')
+        refreshMissingImages(canonical, list).catch((err) => {
+          logger.debug({ err, jid: canonical }, 'media: history refresh failed')
         })
       }
       return
 
     case 'send': {
-      const jid = payload.jid
+      const rawJid = payload.jid
       const text = String(payload.text || '')
-      if (!jid) throw new Error('send: jid required')
+      if (!rawJid) throw new Error('send: jid required')
       if (!text.trim()) throw new Error('send: empty message')
       if (!sock || connection !== 'open') throw new Error('send: not connected to WhatsApp')
 
+      const canonical = store.canonicalJid(rawJid) || rawJid
       const options = {}
       if (payload.quoted) {
-        const list = store.messages.get(jid) || []
+        const list = store.messages.get(canonical) || []
         const quoted = list.find((m) => m.id === payload.quoted)
-        // Baileys needs the original envelope to quote; the flattened copy only
-        // keeps the key, which is enough for a reply stanza.
         if (quoted?.key) options.quoted = { key: quoted.key, message: { conversation: quoted.text } }
       }
 
-      const sent = await sock.sendMessage(jid, { text }, options)
+      const sent = await sock.sendMessage(rawJid, { text }, options)
       if (sent) {
-        const message = ingest(jid, sent, { live: false })
-        if (message) {
-          bus.broadcast({ t: 'message', jid, message: publicMessage(message), chat: store.chat(jid), unread: store.totalUnread() })
+        const res = ingest(rawJid, sent, { live: false })
+        if (res) {
+          const { message, canonicalTarget } = res
+          bus.broadcast({ t: 'message', jid: rawJid, message: publicMessage(message), chat: store.chat(canonicalTarget), unread: store.totalUnread() })
           pushChats()
         }
       }
-      reply({ t: 'ack', id, ok: true, jid })
+      reply({ t: 'ack', id, ok: true, jid: rawJid })
       return
     }
 

--- a/daemon/lib/message.js
+++ b/daemon/lib/message.js
@@ -104,11 +104,24 @@ export function messageType(message) {
   return getContentType(content) || ''
 }
 
+function unwrapMessage(content) {
+  if (!content) return null
+  let curr = content
+  if (curr.viewOnceMessage?.message) curr = curr.viewOnceMessage.message
+  if (curr.viewOnceMessageV2?.message) curr = curr.viewOnceMessageV2.message
+  if (curr.viewOnceMessageV2Extension?.message) curr = curr.viewOnceMessageV2Extension.message
+  if (curr.ephemeralMessage?.message) curr = curr.ephemeralMessage.message
+  if (curr.documentWithCaptionMessage?.message) curr = curr.documentWithCaptionMessage.message
+  if (curr.editedMessage?.message?.protocolMessage?.editedMessage) curr = curr.editedMessage.message.protocolMessage.editedMessage
+  return curr
+}
+
 // Flatten a Baileys message into the single preview line the panel and the
 // notification both want. Media becomes "<icon> Photo" or "<icon> caption".
 export function messageText(message) {
-  const content = normalizeMessageContent(message)
-  if (!content) return ''
+  const rawContent = normalizeMessageContent(message)
+  if (!rawContent) return ''
+  const content = unwrapMessage(rawContent) || rawContent
 
   if (typeof content.conversation === 'string' && content.conversation) return content.conversation
   if (content.extendedTextMessage?.text) return content.extendedTextMessage.text
@@ -119,6 +132,50 @@ export function messageText(message) {
   if (type === 'reactionMessage') {
     const emoji = content.reactionMessage?.text || ''
     return emoji ? `Reacted ${emoji}` : 'Removed a reaction'
+  }
+
+  // Interactive / Business / Bot messages
+  if (type === 'interactiveMessage') {
+    const body = content.interactiveMessage?.body?.text
+    const header = content.interactiveMessage?.header?.title
+    const title = header ? `${header}\n${body || ''}` : body
+    if (title) return title.trim()
+  }
+
+  if (type === 'templateMessage') {
+    const tmpl = content.templateMessage?.hydratedTemplate || content.templateMessage?.fourRowTemplate
+    const text = tmpl?.hydratedContentText || tmpl?.contentText || tmpl?.hydratedTitleText || tmpl?.title
+    if (text) return text.trim()
+  }
+
+  if (type === 'buttonsMessage') {
+    const text = content.buttonsMessage?.contentText || content.buttonsMessage?.caption || content.buttonsMessage?.text
+    if (text) return text.trim()
+  }
+
+  if (type === 'listMessage') {
+    const text = content.listMessage?.description || content.listMessage?.title
+    if (text) return text.trim()
+  }
+
+  if (type === 'interactiveResponseMessage') {
+    const text = content.interactiveResponseMessage?.body?.text || content.interactiveResponseMessage?.nativeFlowResponseMessage?.name
+    if (text) return text.trim()
+  }
+
+  if (type === 'templateButtonReplyMessage') {
+    const text = content.templateButtonReplyMessage?.selectedDisplayText || content.templateButtonReplyMessage?.selectedId
+    if (text) return text.trim()
+  }
+
+  if (type === 'buttonsResponseMessage') {
+    const text = content.buttonsResponseMessage?.selectedDisplayText || content.buttonsResponseMessage?.selectedButtonId
+    if (text) return text.trim()
+  }
+
+  if (type === 'listResponseMessage') {
+    const text = content.listResponseMessage?.title || content.listResponseMessage?.singleSelectReply?.selectedRowId
+    if (text) return text.trim()
   }
 
   if (type === 'documentWithCaptionMessage') {
@@ -152,8 +209,9 @@ function prefixed(type, text) {
 // True when the message is bookkeeping the user never sees, so it must not
 // bump a chat's preview line, unread count, or fire a notification.
 export function isSilent(message) {
-  const content = normalizeMessageContent(message)
-  if (!content) return true
+  const rawContent = normalizeMessageContent(message)
+  if (!rawContent) return true
+  const content = unwrapMessage(rawContent) || rawContent
   const type = getContentType(content)
   if (!type) return true
   if (SILENT_TYPES.has(type)) return true

--- a/daemon/lib/store.js
+++ b/daemon/lib/store.js
@@ -12,6 +12,7 @@ export function normalizeJid(jid) {
   const [user, server] = String(jid).split('@')
   if (!user) return String(jid)
   const bare = user.split(':')[0]
+  if (server === 'c.us') return `${bare}@s.whatsapp.net`
   return server ? `${bare}@${server}` : bare
 }
 
@@ -41,6 +42,19 @@ export class Store {
     this._dirty = false
   }
 
+  canonicalJid(jid) {
+    const key = normalizeJid(jid)
+    if (!key) return ''
+    const target = this.aliases.get(key)
+    if (target) {
+      const normTarget = normalizeJid(target)
+      if (normTarget.endsWith('@s.whatsapp.net')) return normTarget
+      if (key.endsWith('@s.whatsapp.net')) return key
+      return normTarget || key
+    }
+    return key
+  }
+
   load() {
     let raw
     try {
@@ -61,6 +75,13 @@ export class Store {
       for (const list of this.messages.values()) {
         for (const message of list) {
           if (message.imagePath && !existsSync(message.imagePath)) message.imagePath = ''
+        }
+      }
+      for (const [from, to] of this.aliases.entries()) {
+        const primary = this.canonicalJid(from)
+        const secondary = (primary === normalizeJid(from)) ? normalizeJid(to) : normalizeJid(from)
+        if (primary && secondary && primary !== secondary) {
+          this._mergeJids(primary, secondary)
         }
       }
       this.applyNamesToChats()
@@ -104,8 +125,6 @@ export class Store {
     }
     const tmp = `${storeFile}.tmp`
     try {
-      // Write-then-rename: a crash mid-write leaves the previous snapshot
-      // intact instead of a half-written file the next start cannot parse.
       writeFileSync(tmp, JSON.stringify(payload), { mode: 0o600 })
       renameSync(tmp, storeFile)
     } catch (err) {
@@ -115,7 +134,7 @@ export class Store {
 
   rememberName(jid, name) {
     if (!jid || !name) return false
-    const key = normalizeJid(jid)
+    const key = this.canonicalJid(jid) || normalizeJid(jid)
     const clean = String(name).trim().replace(/[\u200e\u200f\u202a-\u202e]/g, '')
     if (!key || !clean) return false
 
@@ -128,11 +147,12 @@ export class Store {
 
     this.names.set(key, clean)
     const aliased = this.aliases.get(key)
-    if (aliased && (isPlaceholderName(this.names.get(aliased)) || !this.names.get(aliased))) {
-      this.names.set(aliased, clean)
+    if (aliased) {
+      const normAliased = normalizeJid(aliased)
+      this.names.set(normAliased, clean)
+      this._applyName(normAliased, clean)
     }
     this._applyName(key, clean)
-    if (aliased) this._applyName(aliased, clean)
     this.markDirty()
     return true
   }
@@ -141,20 +161,84 @@ export class Store {
     const left = normalizeJid(a)
     const right = normalizeJid(b)
     if (!left || !right || left === right) return false
-    if (this.aliases.get(left) === right && this.aliases.get(right) === left) return false
-    this.aliases.set(left, right)
-    this.aliases.set(right, left)
-    const name = this.lookupName(left) || this.lookupName(right)
-    if (name) {
-      this.rememberName(left, name)
-      this.rememberName(right, name)
+
+    let primary = left
+    let secondary = right
+    if (right.endsWith('@s.whatsapp.net') && !left.endsWith('@s.whatsapp.net')) {
+      primary = right
+      secondary = left
     }
+
+    const prevP = this.aliases.get(primary)
+    const prevS = this.aliases.get(secondary)
+    if (prevP === secondary && prevS === primary) {
+      this._mergeJids(primary, secondary)
+      return false
+    }
+
+    this.aliases.set(primary, secondary)
+    this.aliases.set(secondary, primary)
+
+    const nameP = this.lookupName(primary)
+    const nameS = this.lookupName(secondary)
+    const bestName = (!isPlaceholderName(nameP) ? nameP : nameS) || (!isPlaceholderName(nameS) ? nameS : '')
+    if (bestName) {
+      this.rememberName(primary, bestName)
+      this.rememberName(secondary, bestName)
+    }
+
+    this._mergeJids(primary, secondary)
     this.markDirty()
     return true
   }
 
+  _mergeJids(primary, secondary) {
+    if (!primary || !secondary || primary === secondary) return
+
+    const secondaryMsgs = this.messages.get(secondary)
+    if (secondaryMsgs && secondaryMsgs.length > 0) {
+      const primaryMsgs = this.messages.get(primary) || []
+      const mergedMap = new Map()
+      for (const m of primaryMsgs) mergedMap.set(m.id, m)
+      for (const m of secondaryMsgs) {
+        if (!mergedMap.has(m.id)) {
+          mergedMap.set(m.id, m)
+        } else {
+          mergedMap.set(m.id, { ...mergedMap.get(m.id), ...m })
+        }
+      }
+      const mergedList = [...mergedMap.values()].sort((a, b) => (a.ts || 0) - (b.ts || 0))
+      if (mergedList.length > MAX_MESSAGES_PER_CHAT) {
+        mergedList.splice(0, mergedList.length - MAX_MESSAGES_PER_CHAT)
+      }
+      this.messages.set(primary, mergedList)
+      this.messages.delete(secondary)
+    }
+
+    const chatS = this.chats.get(secondary)
+    if (chatS) {
+      const chatP = this.chat(primary)
+      if ((chatS.lastTs || 0) > (chatP.lastTs || 0)) {
+        chatP.lastTs = chatS.lastTs
+        chatP.lastText = chatS.lastText
+        chatP.lastFromMe = chatS.lastFromMe
+        chatP.lastSender = chatS.lastSender
+      }
+      chatP.unread = Math.max(chatP.unread || 0, chatS.unread || 0)
+      chatP.muted = chatP.muted || chatS.muted
+      chatP.archived = chatP.archived || chatS.archived
+      chatP.pinned = chatP.pinned || chatS.pinned
+
+      if (isPlaceholderName(chatP.name) && !isPlaceholderName(chatS.name)) {
+        chatP.name = chatS.name
+      }
+
+      this.chats.delete(secondary)
+    }
+  }
+
   lookupName(jid) {
-    const key = normalizeJid(jid)
+    const key = this.canonicalJid(jid) || normalizeJid(jid)
     if (!key) return ''
     return this.names.get(key) || this.names.get(this.aliases.get(key) || '') || ''
   }
@@ -164,7 +248,8 @@ export class Store {
   }
 
   _applyName(jid, name) {
-    const chat = this.chats.get(jid)
+    const key = this.canonicalJid(jid) || normalizeJid(jid)
+    const chat = this.chats.get(key)
     if (!chat) return
     if (chat.nameLocked && !isPlaceholderName(chat.name)) return
     if (chat.name === name) return
@@ -187,7 +272,7 @@ export class Store {
   }
 
   chat(jid) {
-    const key = normalizeJid(jid) || jid
+    const key = this.canonicalJid(jid) || normalizeJid(jid) || jid
     let chat = this.chats.get(key)
     if (!chat) {
       chat = {
@@ -212,18 +297,15 @@ export class Store {
     return chat
   }
 
-  // Insert or replace a message, keeping each chat's list sorted by timestamp
-  // so out-of-order delivery (history sync racing live traffic) still renders
-  // in the right order.
   upsertMessage(jid, message) {
-    const key = normalizeJid(jid) || jid
-    const list = this.messages.get(key) || this.messages.get(jid) || []
+    const key = this.canonicalJid(jid) || normalizeJid(jid) || jid
+    const list = this.messages.get(key) || []
     const existing = list.findIndex((m) => m.id === message.id)
     if (existing !== -1) {
       list[existing] = { ...list[existing], ...message }
     } else {
       list.push(message)
-      list.sort((a, b) => a.ts - b.ts)
+      list.sort((a, b) => (a.ts || 0) - (b.ts || 0))
       if (list.length > MAX_MESSAGES_PER_CHAT) list.splice(0, list.length - MAX_MESSAGES_PER_CHAT)
     }
     this.messages.set(key, list)
@@ -231,12 +313,10 @@ export class Store {
     return list
   }
 
-  // A chat's preview line only moves forward in time, so a late history-sync
-  // message can never overwrite the newest one the user just received.
   touchChat(jid, message) {
     const chat = this.chat(jid)
-    if (message.ts >= (chat.lastTs || 0)) {
-      chat.lastTs = message.ts
+    if ((message.ts || 0) >= (chat.lastTs || 0)) {
+      chat.lastTs = message.ts || 0
       chat.lastText = message.text
       chat.lastFromMe = !!message.fromMe
       chat.lastSender = message.senderName || ''
@@ -284,21 +364,21 @@ export class Store {
   }
 
   messageList(jid, limit = 60) {
-    const list = this.messages.get(normalizeJid(jid) || jid) || this.messages.get(jid) || []
+    const key = this.canonicalJid(jid) || normalizeJid(jid) || jid
+    const list = this.messages.get(key) || []
     return list.slice(-Math.max(1, limit))
   }
 
   findMessage(jid, id) {
     if (!id) return null
-    const keys = [jid, normalizeJid(jid), this.aliases.get(normalizeJid(jid) || jid)].filter(Boolean)
-    for (const key of keys) {
-      const list = this.messages.get(key)
-      const found = list?.find((m) => m.id === id)
-      if (found) return found
-    }
-    for (const list of this.messages.values()) {
-      const found = list.find((m) => m.id === id)
-      if (found) return found
+    const key = this.canonicalJid(jid) || normalizeJid(jid) || jid
+    const list = this.messages.get(key)
+    const found = list?.find((m) => m.id === id)
+    if (found) return found
+
+    for (const l of this.messages.values()) {
+      const f = l.find((m) => m.id === id)
+      if (f) return f
     }
     return null
   }
@@ -313,3 +393,4 @@ export class Store {
     this.persist()
   }
 }
+


### PR DESCRIPTION
# PR: Fix Contact Name Corruption, Merge Aliased JIDs, and Support Business/Bot Messages

### 1. Issue & Background
Three core data bugs impacted message accuracy and chat history display in the daemon:
1. **Contact Name Corruption**: When the user sent an outgoing message (`fromMe: true`), `raw.pushName` contained the user's own push name (e.g. "Ahmet"). `Store.rememberName()` was called without checking `fromMe`, overwriting recipient contact names with the sender's own name.
2. **Split Chat History & Duplicate Chats**: WhatsApp Baileys protocol delivers messages using both primary phone JIDs (`@s.whatsapp.net`) and linked-device JIDs (`@lid`). The daemon previously maintained separate chat objects and split message arrays for `@lid` and `@s.whatsapp.net`. Aliasing only registered mapping entries without merging existing message lists or removing redundant LID chat objects.
3. **Missing Business & Bot Messages**: WhatsApp Business API, official accounts, and interactive bots transmit messages as `templateMessage`, `interactiveMessage`, `buttonsMessage`, or `listMessage`. `messageText()` returned empty string `""` for these message structures, causing `isSilent()` to classify them as silent bookkeeping traffic and `ingest()` to discard them completely.

### 2. Rationale
These issues resulted in corrupted contact lists, incomplete/fragmented message history, and missing order updates, OTPs, or bot responses. Resolving them ensures accurate chat history and full message visibility.

### 3. Implementation & Solution
- **Contact Name Protection (`daemon/index.js`)**:
  - Enforced `!raw.key?.fromMe` guard inside `ingest()` before invoking `store.rememberName()` for direct and group participant messages.
- **Canonical JID Resolution & Chat Merging (`daemon/lib/store.js`)**:
  - Implemented `canonicalJid(jid)` to resolve `@lid` JIDs to primary `@s.whatsapp.net` JIDs.
  - Implemented `_mergeJids(primary, secondary)` to merge message arrays (deduplicating by message ID and sorting by timestamp) and combine chat metadata.
  - Updated `Store.load()` to auto-merge existing aliased chats on daemon startup.
- **Business/Bot Payload Unwrapping (`daemon/lib/message.js`)**:
  - Added `unwrapMessage()` to unwrap `viewOnceMessage`, `ephemeralMessage`, `editedMessage`, and `documentWithCaptionMessage` payloads.
  - Extended `messageText()` to extract text from `templateMessage`, `interactiveMessage`, `buttonsMessage`, `listMessage`, `interactiveResponseMessage`, `templateButtonReplyMessage`, `buttonsResponseMessage`, and `listResponseMessage`.
  - Mapped `@c.us` server JIDs to `@s.whatsapp.net` in `normalizeJid()`.

---

## How to Test
1. Send outgoing messages to contacts and verify recipient contact names remain intact.
2. Receive messages from contacts using LID JIDs and verify chat history remains unified under single chat entry without duplicate records.
3. Receive OTP, shipment notifications, or bot interactive menu messages and verify they are correctly displayed in the chat panel.
