### PR TITLE
fix(daemon): Synchronize read receipts, unread status, and 'Mark as Unread' from phone and linked devices

### DIFF
--- a/daemon/index.js
+++ b/daemon/index.js
@@ -233,8 +233,21 @@ function ingest(chatJid, raw, { live }) {
 
   resolveGroupName(canonicalTarget)
 
-  if (live && !existed && !message.fromMe) {
-    store.bumpUnread(canonicalTarget)
+  if (message.fromMe) {
+    store.setUnread(canonicalTarget, 0)
+  } else if (live && !existed) {
+    const currentUnread = chat.unread || 0
+    const now = Date.now()
+    if (currentUnread === 0) {
+      store.setUnread(canonicalTarget, 1)
+    } else if (currentUnread === 1 && chat.lastUnreadSync && (now - chat.lastUnreadSync < 5000)) {
+      // chats.update or metadata sync already set unread to 1 for this incoming message
+      store.setUnread(canonicalTarget, 1)
+    } else {
+      store.bumpUnread(canonicalTarget)
+    }
+    chat.lastUnreadSync = now
+
     if (message.ts >= startedAt) {
       const title = chat.isGroup ? (chat.name || 'Group') : (message.senderName || chat.name)
       const body = chat.isGroup ? `${message.senderName}: ${message.text}` : message.text
@@ -250,14 +263,25 @@ function ingest(chatJid, raw, { live }) {
 }
 
 function applyChatMetadata(rawChats) {
+  let unreadChanged = false
   for (const raw of rawChats || []) {
     const jid = raw?.id
     if (!jid || isIgnorableChat(jid)) continue
-    if (raw.pnJid) store.alias(jid, raw.pnJid)
-    if (raw.lidJid) store.alias(jid, raw.lidJid)
-    const chat = store.chat(jid)
-    if (raw.name) store.rememberName(jid, raw.name)
-    if (typeof raw.unreadCount === 'number') chat.unread = Math.max(0, raw.unreadCount)
+    const canonical = store.canonicalJid(jid) || normalizeJid(jid) || jid
+    if (raw.pnJid) store.alias(canonical, raw.pnJid)
+    if (raw.lidJid) store.alias(canonical, raw.lidJid)
+    const chat = store.chat(canonical)
+    if (raw.name) store.rememberName(canonical, raw.name)
+
+    if (raw.unreadCount !== undefined && raw.unreadCount !== null) {
+      const count = typeof raw.unreadCount === 'number' ? Math.max(0, raw.unreadCount) : 0
+      if (chat.unread !== count) {
+        store.setUnread(canonical, count)
+        unreadChanged = true
+      }
+      chat.lastUnreadSync = Date.now()
+    }
+
     if (raw.conversationTimestamp !== undefined) {
       const ts = toTs(raw.conversationTimestamp)
       if (ts > (chat.lastTs || 0)) chat.lastTs = ts
@@ -271,6 +295,7 @@ function applyChatMetadata(rawChats) {
   }
   store.applyNamesToChats()
   store.markDirty()
+  return unreadChanged
 }
 
 function asLidJid(value) {
@@ -665,8 +690,10 @@ async function connect() {
 
     sock.ev.on('chats.update', (updates) => {
       if (sock !== thisSocket) return
-      applyChatMetadata(updates)
+      const before = store.totalUnread()
+      const unreadChanged = applyChatMetadata(updates)
       pushChatsSoon()
+      if (unreadChanged || store.totalUnread() !== before) pushState()
     })
 
     sock.ev.on('chats.delete', (jids) => {
@@ -736,34 +763,66 @@ async function connect() {
 
     sock.ev.on('messages.update', (updates) => {
       if (sock !== thisSocket) return
+      const before = store.totalUnread()
+      let unreadCleared = false
       for (const update of updates || []) {
-        const jid = update?.key?.remoteJid
-        const id = update?.key?.id
-        if (!jid || !id) continue
-        const found = store.findMessage(jid, id)
+        const jid = update?.key?.remoteJid || update?.remoteJid
+        if (!jid) continue
+        const canonical = store.canonicalJid(jid) || normalizeJid(jid) || jid
+
+        const u = update.update || update
+        if (u.readTimestamp || u.status === 3 || u.status === 4 || u.type === 'read-self') {
+          store.setUnread(canonical, 0)
+          unreadCleared = true
+        }
+
+        const id = update?.key?.id || update?.id
+        if (!id) continue
+        const found = store.findMessage(canonical, id)
         if (!found) continue
-        const status = update.update?.status
-        if (typeof status !== 'number') continue
-        if (status < (found.status || 0)) continue
+        const status = typeof u.status === 'number' ? u.status : (u.readTimestamp ? 4 : 0)
+        if (!status || status < (found.status || 0)) continue
         found.status = status
         store.markDirty()
-        bus.broadcast({ t: 'messageStatus', jid: found.key?.remoteJid || jid, id, status })
+        bus.broadcast({ t: 'messageStatus', jid: found.key?.remoteJid || canonical, id, status })
+      }
+      if (unreadCleared || store.totalUnread() !== before) {
+        pushChatsSoon()
+        pushState()
       }
     })
 
     sock.ev.on('message-receipt.update', (updates) => {
       if (sock !== thisSocket) return
+      const before = store.totalUnread()
+      let unreadCleared = false
       for (const update of updates || []) {
         const jid = update?.key?.remoteJid
+        if (!jid) continue
+        const canonical = store.canonicalJid(jid) || normalizeJid(jid) || jid
+
+        const receipt = update.receipt || {}
+        const receiptType = receipt.receiptType || receipt.type
+        const isReadReceipt = receipt.readTimestamp || receiptType === 'read' || receiptType === 'read-self'
+
+        if (isReadReceipt) {
+          store.setUnread(canonical, 0)
+          unreadCleared = true
+        }
+
         const id = update?.key?.id
-        if (!jid || !id) continue
-        const found = store.findMessage(jid, id)
+        if (!id) continue
+        const found = store.findMessage(canonical, id)
         if (!found) continue
-        const next = update.receipt?.readTimestamp ? 4 : (update.receipt?.receiptTimestamp ? 3 : 0)
+        const next = receipt.readTimestamp ? 4 : (receipt.receiptTimestamp ? 3 : 0)
         if (!next || next < (found.status || 0)) continue
         found.status = next
         store.markDirty()
-        bus.broadcast({ t: 'messageStatus', jid: found.key?.remoteJid || jid, id, status: next })
+        bus.broadcast({ t: 'messageStatus', jid: found.key?.remoteJid || canonical, id, status: next })
+      }
+      if (unreadCleared || store.totalUnread() !== before) {
+        pushChatsSoon()
+        pushState()
       }
     })
   } catch (err) {

--- a/daemon/index.js
+++ b/daemon/index.js
@@ -274,9 +274,25 @@ function applyChatMetadata(rawChats) {
     if (raw.name) store.rememberName(canonical, raw.name)
 
     if (raw.unreadCount !== undefined && raw.unreadCount !== null) {
-      const count = typeof raw.unreadCount === 'number' ? Math.max(0, raw.unreadCount) : 0
+      let count = 0
+      if (typeof raw.unreadCount === 'number') {
+        // In WhatsApp protocol, unreadCount = -1 means "marked as unread" on another device
+        count = raw.unreadCount < 0 ? 1 : raw.unreadCount
+      }
       if (chat.unread !== count) {
         store.setUnread(canonical, count)
+        unreadChanged = true
+      }
+      chat.lastUnreadSync = Date.now()
+    } else if (raw.unread === true || raw.markedUnread === true) {
+      if (chat.unread === 0) {
+        store.setUnread(canonical, 1)
+        unreadChanged = true
+      }
+      chat.lastUnreadSync = Date.now()
+    } else if (raw.unread === false || raw.read === true) {
+      if (chat.unread !== 0) {
+        store.setUnread(canonical, 0)
         unreadChanged = true
       }
       chat.lastUnreadSync = Date.now()

--- a/daemon/lib/store.js
+++ b/daemon/lib/store.js
@@ -326,37 +326,68 @@ export class Store {
   }
 
   setUnread(jid, count) {
-    const chat = this.chat(jid)
+    const key = this.canonicalJid(jid) || normalizeJid(jid) || jid
+    const chat = this.chat(key)
     const next = Math.max(0, count | 0)
-    if (chat.unread === next) return chat
     chat.unread = next
+
+    const aliased = this.aliases.get(key)
+    if (aliased) {
+      const altKey = normalizeJid(aliased)
+      const altChat = this.chats.get(altKey)
+      if (altChat) altChat.unread = next
+    }
     this.markDirty()
     return chat
   }
 
   bumpUnread(jid) {
-    const chat = this.chat(jid)
-    chat.unread = (chat.unread || 0) + 1
+    const key = this.canonicalJid(jid) || normalizeJid(jid) || jid
+    const chat = this.chat(key)
+    const next = (chat.unread || 0) + 1
+    chat.unread = next
+
+    const aliased = this.aliases.get(key)
+    if (aliased) {
+      const altKey = normalizeJid(aliased)
+      const altChat = this.chats.get(altKey)
+      if (altChat) altChat.unread = next
+    }
     this.markDirty()
     return chat
   }
 
   totalUnread() {
     let total = 0
+    const seen = new Set()
     for (const chat of this.chats.values()) {
-      if (chat.muted) continue
-      total += Math.max(0, chat.unread || 0)
+      if (!chat || chat.muted) continue
+      const canonical = this.canonicalJid(chat.jid) || chat.jid
+      if (seen.has(canonical)) continue
+      seen.add(canonical)
+      const canonicalChat = this.chat(canonical)
+      total += Math.max(0, canonicalChat.unread || 0)
     }
     return total
   }
 
   sortedChats() {
-    return [...this.chats.values()]
-      .filter((chat) => chat.lastTs > 0 || chat.unread > 0)
-      .sort((a, b) => {
-        if (!!b.pinned !== !!a.pinned) return b.pinned ? 1 : -1
-        return (b.lastTs || 0) - (a.lastTs || 0)
-      })
+    const seen = new Set()
+    const list = []
+    for (const chat of this.chats.values()) {
+      if (!chat) continue
+      const canonical = this.canonicalJid(chat.jid) || chat.jid
+      if (seen.has(canonical)) continue
+      seen.add(canonical)
+      const canonicalChat = this.chat(canonical)
+      if (canonicalChat.lastTs > 0 || canonicalChat.unread > 0) {
+        list.push(canonicalChat)
+      }
+    }
+    return list.sort((a, b) => {
+      if (!!b.pinned !== !!a.pinned) return b.pinned ? 1 : -1
+      return (b.lastTs || 0) - (a.lastTs || 0)
+    })
   }
 
   chatList(limit = 40) {


### PR DESCRIPTION
# Synchronize Read Receipts, Unread Status, and 'Mark as Unread' from Phone and Linked Devices

### 1. Issue & Background
Four interrelated read-state issues affected multi-device synchronization between the phone app and the Omarchy desktop shell widget:
1. **Stale Unread Badges on Read-Self**: When opening or reading a conversation on a phone or another WhatsApp Web client, the Omarchy top bar unread badge and chat panel failed to clear.
2. **Ghost Unread Counts Across Aliases**: WhatsApp delivers traffic using both primary phone JIDs (`@s.whatsapp.net`) and linked-device JIDs (`@lid`). Setting `unread = 0` on the primary JID left secondary `@lid` chat objects in memory with `unread = 1`, causing `totalUnread()` to continue reporting unread badges on the bar.
3. **Double Counting Race Condition (1 Message = 2 Unread)**: When a new incoming message arrived, WhatsApp's `chats.update` event (setting `unreadCount = 1`) and `messages.upsert` event coincided within milliseconds. `ingest()` unconditionally bumped `chat.unread` after `chats.update` had already set it, turning 1 unread message into 2.
4. **Missing 'Mark as Unread' Synchronization**: Selecting "Mark as Unread" on a phone sends protocol payloads (`unreadCount = -1` or `markedUnread: true`). The daemon previously clamped negative `unreadCount` values to `0` via `Math.max(0, count)`, ignoring the "Mark as Unread" action.

### 2. Rationale
Seamless multi-device state synchronization is essential for a desktop messaging widget. Reading a chat, marking it unread, or sending a reply from any linked device should instantly reflect across the desktop shell in real time without requiring an app restart or manual intervention.

### 3. Implementation & Solution

The PR consists of two clean, independent commits:

#### Commit 1: `fix(daemon): Synchronize read receipts, canonical unread deduplication, and prevent race conditions` (`78d1fad`)
- **Canonical JID Deduplication in `Store` (`daemon/lib/store.js`)**:
  - Updated `totalUnread()`, `sortedChats()`, `setUnread()`, and `bumpUnread()` to deduplicate chats by canonical JIDs (`@s.whatsapp.net` vs `@lid`).
  - Ensures `setUnread(jid, 0)` synchronously resets unread counts across both primary and aliased secondary chat entries in memory.
- **Read-Self Receipt Processing (`daemon/index.js`)**:
  - Updated `message-receipt.update` and `messages.update` handlers to detect `readTimestamp`, `status === 3/4`, and `read-self` receipt types, automatically invoking `store.setUnread(canonical, 0)`.
- **Race Condition & Double Counting Prevention (`daemon/index.js`)**:
  - Added `lastUnreadSync` timestamp tracking to `applyChatMetadata()` and `ingest()`. If `chats.update` or metadata sync set `unread = 1` for a message batch, `ingest()` maintains `unread = 1` instead of bumping to `2`.
- **Outgoing Message Unread Reset (`daemon/index.js`)**:
  - Configured `ingest()` to clear unread counts (`store.setUnread(canonicalTarget, 0)`) whenever an outgoing message (`message.fromMe === true`) is sent from the phone or another client.

#### Commit 2: `feat(daemon): Support 'Mark as Unread' synchronization from phone and linked devices` (`3d6a0a7`)
- **Protocol Payload Parsing in `applyChatMetadata()` (`daemon/index.js`)**:
  - Added support for `unreadCount < 0` (WhatsApp protocol value `-1` representing "Mark as Unread"), converting it to `chat.unread = 1`.
  - Added support for explicit `unread: true`, `markedUnread: true`, and `read: true` flags sent by WhatsApp server sync stanzas.

---

## How to Test
1. **Read-Self Synchronization**:
   - Receive a message on WhatsApp so that the Omarchy top bar displays an unread badge.
   - Open and read the conversation on your phone (or WhatsApp Web on another device).
   - Verify that the unread badge on the Omarchy bar immediately disappears and the chat row updates to read status in real time.
2. **Accurate 1-to-1 Unread Count**:
   - Receive 1 new unread message from a contact.
   - Verify that the unread badge displays exactly `1` (and not `2`).
3. **Mark as Unread**:
   - Right-click a read chat on your phone and select **Mark as Unread**.
   - Verify that the chat immediately receives an unread dot and the unread badge appears on the Omarchy top bar.
4. **Outgoing Reply Reset**:
   - Send a reply from your phone to a chat with unread messages.
   - Verify that the unread badge is automatically cleared.
