### PR TITLE
fix(daemon): Prioritize phone address book contact names over WhatsApp push names

### DIFF
--- a/daemon/index.js
+++ b/daemon/index.js
@@ -223,12 +223,12 @@ function ingest(chatJid, raw, { live }) {
   const chat = store.touchChat(canonicalTarget, message)
 
   if (!chat.isGroup && !raw.key?.fromMe && raw.pushName) {
-    store.rememberName(canonicalTarget, raw.pushName)
+    store.rememberPushName(canonicalTarget, raw.pushName)
   }
 
   const participant = raw.key?.participant || raw.participant
   if (chat.isGroup && !raw.key?.fromMe && participant && raw.pushName) {
-    store.rememberName(participant, raw.pushName)
+    store.rememberPushName(participant, raw.pushName)
   }
 
   resolveGroupName(canonicalTarget)
@@ -332,9 +332,13 @@ function applyContacts(contacts) {
     if (!contact?.id && !contact?.lid && !contact?.jid) continue
     const ids = [contact.id, contact.lid, contact.jid].filter(Boolean).map((id) => normalizeJid(id) || id)
     for (let i = 1; i < ids.length; i++) store.alias(ids[0], ids[i])
-    const name = contact.name || contact.verifiedName || contact.notify
-    if (!name) continue
-    for (const id of ids) store.rememberName(id, name)
+    const addressBookName = contact.name || contact.verifiedName
+    const pushName = contact.notify
+    if (addressBookName) {
+      for (const id of ids) store.rememberContactName(id, addressBookName)
+    } else if (pushName) {
+      for (const id of ids) store.rememberPushName(id, pushName)
+    }
   }
   store.applyNamesToChats()
 }

--- a/daemon/lib/store.js
+++ b/daemon/lib/store.js
@@ -35,6 +35,8 @@ export class Store {
     this.messages = new Map()
     /** @type {Map<string, string>} */
     this.names = new Map()
+    /** @type {Set<string>} */
+    this.addressBookKeys = new Set()
     /** @type {Map<string, string>} */
     this.aliases = new Map()
     this.me = null
@@ -70,6 +72,7 @@ export class Store {
         if (Array.isArray(list)) this.messages.set(jid, list.slice(-MAX_MESSAGES_PER_CHAT))
       }
       for (const [jid, name] of Object.entries(data.names || {})) this.names.set(jid, name)
+      for (const key of data.addressBookKeys || []) this.addressBookKeys.add(key)
       for (const [from, to] of Object.entries(data.aliases || {})) this.aliases.set(from, to)
       this.me = data.me || null
       for (const list of this.messages.values()) {
@@ -121,6 +124,7 @@ export class Store {
       chats,
       messages,
       names: Object.fromEntries(this.names),
+      addressBookKeys: [...this.addressBookKeys],
       aliases: Object.fromEntries(this.aliases)
     }
     const tmp = `${storeFile}.tmp`
@@ -132,29 +136,44 @@ export class Store {
     }
   }
 
-  rememberName(jid, name) {
+  rememberName(jid, name, isAddressBook = false) {
     if (!jid || !name) return false
     const key = this.canonicalJid(jid) || normalizeJid(jid)
     const clean = String(name).trim().replace(/[\u200e\u200f\u202a-\u202e]/g, '')
-    if (!key || !clean) return false
+    if (!key || !clean || isPlaceholderName(clean)) return false
+
+    const hasAddressBookName = this.addressBookKeys.has(key)
+    if (hasAddressBookName && !isAddressBook) return false
 
     const existing = this.names.get(key)
-    if (existing === clean) {
+    if (existing === clean && (isAddressBook ? hasAddressBookName : !hasAddressBookName)) {
       this._applyName(key, clean)
       return false
     }
-    if (existing && !isPlaceholderName(existing) && isPlaceholderName(clean)) return false
+
+    if (isAddressBook) {
+      this.addressBookKeys.add(key)
+    }
 
     this.names.set(key, clean)
     const aliased = this.aliases.get(key)
     if (aliased) {
       const normAliased = normalizeJid(aliased)
       this.names.set(normAliased, clean)
+      if (isAddressBook) this.addressBookKeys.add(normAliased)
       this._applyName(normAliased, clean)
     }
     this._applyName(key, clean)
     this.markDirty()
     return true
+  }
+
+  rememberContactName(jid, name) {
+    return this.rememberName(jid, name, true)
+  }
+
+  rememberPushName(jid, name) {
+    return this.rememberName(jid, name, false)
   }
 
   alias(a, b) {


### PR DESCRIPTION
# Prioritize Phone Address Book Contact Names Over WhatsApp Push Names

## Description

### 1. Issue & Background
In the original daemon implementation, when an incoming message arrived from a contact, `ingest()` called `store.rememberName(canonicalTarget, raw.pushName)`. This unconditionally replaced whatever contact name was stored in memory with the sender's WhatsApp push name (`raw.pushName` / `notify`). As a result, contacts saved in the user's phone address book (e.g. "Mehmet Amca") were overwritten by their custom WhatsApp profile names (e.g. "~Mehmet_06").

### 2. Rationale
Users expect contacts saved in their phone address book to display with their familiar address book names. Custom WhatsApp push names chosen by recipients should only serve as a secondary fallback for contacts not saved in the user's address book.

### 3. Implementation & Solution

The PR consists of one clean commit:

#### Commit 1: `fix(daemon): Prioritize phone address book contact names over WhatsApp push names` (`7c13ed7`)
- **Address Book Key Tracking in `Store` (`daemon/lib/store.js`)**:
  - Added `addressBookKeys` (`Set<string>`) to track JIDs that have explicit address book names (`contact.name` or `contact.verifiedName`) synced from the phone.
  - Updated `rememberName(jid, name, isAddressBook)`:
    - If `isAddressBook` is `true` (synced via `contacts.upsert`/`contacts.update`), the name is stored as an authoritative address book name and added to `addressBookKeys`.
    - If `isAddressBook` is `false` (push name via `raw.pushName`), it is ignored if an address book name already exists for that JID.
  - Added helper methods `rememberContactName()` and `rememberPushName()`.
  - Persisted `addressBookKeys` in the local JSON snapshot payload (`storeFile`).
- **Priority Routing in `daemon/index.js`**:
  - Updated `applyContacts()` to call `rememberContactName()` for `contact.name` / `contact.verifiedName`, and `rememberPushName()` for `contact.notify`.
  - Updated `ingest()` to use `rememberPushName()` for incoming `raw.pushName` payloads, preventing incoming messages from overwriting saved phone contacts.

---

## How to Test
1. Connect a linked WhatsApp account with contacts saved in the phone's address book (e.g. "Mom" or "John").
2. Receive incoming messages from saved contacts who have custom push names set on WhatsApp.
3. Verify that the chat list and panel continue to display the saved phone address book name ("Mom") instead of being overwritten by the push name.
4. Receive a message from an unsaved number and verify that their WhatsApp push name is displayed as a fallback.
